### PR TITLE
Add a more detailed profile page stub

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_app/profile/profilepage.dart';
+import 'package:outlook/profile/profilepage.dart';
 
 void main() => runApp(MyApp());
 

--- a/frontend/lib/profile/cover.dart
+++ b/frontend/lib/profile/cover.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:math';
 
 class Cover extends StatefulWidget {
   Cover({Key key, this.name, this.username}): super(key: key);
@@ -18,7 +19,7 @@ class _CoverState extends State<Cover> {
       width: MediaQuery.of(context).size.width,
       color: Color.fromRGBO(0, 0, 0, 0.2),
       constraints: BoxConstraints(
-        maxHeight: 250
+        maxHeight: min(MediaQuery.of(context).size.height / 3, 200)
       ),
       child: Center(
         child: Column(
@@ -38,14 +39,15 @@ class ProfilePicture extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       constraints: BoxConstraints(
-          maxHeight: 150,
-          maxWidth: 150
+          maxHeight: 100,
+          maxWidth: 100
       ),
       decoration: BoxDecoration(
           border: Border.all(
               color: Colors.white,
               width: 5
           ),
+          borderRadius: BorderRadius.all(Radius.circular(100)),
           color: Colors.white,
           image:  DecorationImage(
               image: AssetImage('assets/defaultprofilepic.jpg')
@@ -70,7 +72,7 @@ class ProfileName extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-        padding: EdgeInsets.only(top: 15),
+        padding: EdgeInsets.only(top: 10),
         child: Column(
           children: <Widget>[
             Text(name, style: TextStyle(
@@ -78,12 +80,13 @@ class ProfileName extends StatelessWidget {
               color: Colors.white,
             )),
             Padding(
-              padding: EdgeInsets.only(top: 5),
+              padding: EdgeInsets.only(top: 2),
               child: Text('@'+username, style: TextStyle(
                 fontSize: 14,
                 color: Colors.white,
               ))
-            )
+            ),
+            Container()
           ],
         )
     );

--- a/frontend/lib/profile/profilepage.dart
+++ b/frontend/lib/profile/profilepage.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_app/profile/cover.dart';
-import 'package:flutter_app/profile/section-control/sectionControl.dart';
+import 'package:outlook/profile/cover.dart';
+import 'package:outlook/profile/section-control/sectionControl.dart';
 
 class ProfilePage extends StatefulWidget {
   ProfilePage({Key key}): super(key: key);
@@ -23,10 +23,12 @@ class _ProfilePageState extends State<ProfilePage> {
           backgroundColor: Color(0),
         ),
         body: Column(
-          children: <Widget>[
-            Cover(name: 'Clayton Chu', username: 'clayton'),
-            SectionControl()
-          ]
+            children: <Widget>[
+              Cover(name: 'Clayton Chu', username: 'clayton'),
+              Flexible(
+                child: SectionControl()
+              )
+            ]
         )
     );
   }

--- a/frontend/lib/profile/section-control/sectionControl.dart
+++ b/frontend/lib/profile/section-control/sectionControl.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_app/profile/section-control/sectionControlNav.dart';
+import 'package:outlook/profile/sections/activity.dart';
+import 'package:outlook/profile/sections/following.dart';
+import 'package:outlook/profile/section-control/sectionControlNav.dart';
+import 'package:outlook/profile/sections/about.dart';
+
+PageController _controller = PageController(initialPage: 0);
 
 class SectionControl extends StatefulWidget {
   SectionControl({Key key}): super(key: key);
@@ -9,21 +14,49 @@ class SectionControl extends StatefulWidget {
 
 class _SectionControlState extends State<SectionControl> {
 
-  String currentSection = "Activity";
+  int currentPage = 0;
 
-  void _changeSection(section) {
+  void _changeSection(int page) {
     setState(() {
-      currentSection = section;
+      currentPage = page;
     });
+    _controller.animateToPage(page, duration: Duration(milliseconds: 1000), curve: Curves.easeInOut);
+    _controller.jumpToPage(page);
   }
 
   @override
   Widget build(BuildContext context) {
+    Widget section;
+    switch (currentPage) {
+      case 0:
+        section = ActivitySection();
+        break;
+      case 1:
+        section = FollowingSection();
+        break;
+      case 2:
+        section = AboutSection(description: 'hello this is my description and it spans multiple rows just trying it out right now');
+        break;
+      default:
+        section = Text('No information available.');
+    }
+
     return Column(
       children: <Widget>[
-        SectionControlNav(changeSection: this._changeSection),
-        Text(currentSection)
-      ],
+        SectionControlNav(changeSection: _changeSection, currentPage: currentPage),
+        Flexible(
+            child: PageView(
+              children: <Widget>[
+                ActivitySection(),
+                FollowingSection(),
+                AboutSection(description: 'hello this is my description and it spans multiple rows just trying it out right now')
+              ],
+              onPageChanged: _changeSection,
+              controller: _controller,
+            )
+        )
+
+      ]
     );
   }
 }

--- a/frontend/lib/profile/section-control/sectionControlNav.dart
+++ b/frontend/lib/profile/section-control/sectionControlNav.dart
@@ -1,46 +1,69 @@
 import 'package:flutter/material.dart';
 
 class SectionControlNav extends StatelessWidget {
-  SectionControlNav({Key key, this.changeSection}): super(key: key);
+  SectionControlNav({Key key, this.changeSection, this.currentPage}): super(key: key);
 
   final Function changeSection;
+  int currentPage;
 
   @override
   Widget build(BuildContext context) {
     // TODO: implement build
     return Row(
       children: <Widget>[
-        SectionControlButton(changeSection: this.changeSection, name: "Activity"),
-        SectionControlButton(changeSection: this.changeSection, name: "Following"),
-        SectionControlButton(changeSection: this.changeSection, name: "About")
+        SectionControlButton(
+            changeSection: this.changeSection,
+            name: "Activity",
+            currentPage: currentPage,
+            pageIndex: 0
+        ),
+        SectionControlButton(changeSection: this.changeSection,
+            name: "Following",
+            currentPage: currentPage,
+            pageIndex: 1,
+        ),
+        SectionControlButton(changeSection: this.changeSection,
+            name: "About",
+            currentPage: currentPage,
+            pageIndex: 2
+        )
       ],
     );
   }
 }
 
 class SectionControlButton extends StatelessWidget {
-  SectionControlButton({Key key, this.changeSection, this.name}): super(key: key);
+  SectionControlButton({
+    Key key,
+    this.changeSection,
+    this.name,
+    this.currentPage,
+    this.pageIndex
+  }): super(key: key);
 
   final Function changeSection;
   final String name;
+  int currentPage;
+  final int pageIndex;
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
         onTap: () {
-          changeSection(name);
+          changeSection(pageIndex);
         },
         child: Container(
             width: MediaQuery.of(context).size.width / 3,
-            height: 50,
+            height: 40,
             decoration: BoxDecoration(
                 color: Color.fromRGBO(0, 0, 0, 0.1),
                 border: Border(
                   left: BorderSide(color: Color.fromRGBO(0, 0, 0, 0.1), width: 1),
+                  bottom: BorderSide(color: Color.fromRGBO(0, 0, 0, currentPage == pageIndex ? 0.15 : 0), width: 3)
                 )
             ),
             child: Center(
-                child: Text(name, style: TextStyle(fontSize: 16))
+                child: Text(name, style: TextStyle(fontSize: 15))
             )
         )
     );

--- a/frontend/lib/profile/sections/about.dart
+++ b/frontend/lib/profile/sections/about.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AboutSection extends StatelessWidget {
+  AboutSection({Key key, this.description}): super(key: key);
+
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Padding(
+        padding: EdgeInsets.all(20),
+        child: Text(description, style: TextStyle(fontSize: 16))
+      )
+    );
+  }
+}

--- a/frontend/lib/profile/sections/activity.dart
+++ b/frontend/lib/profile/sections/activity.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+class ActivitySection extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Color.fromRGBO(0, 0, 0, 0.02),
+      child: ListView(
+          children: <Widget>[
+            Comment(
+                text: 'Well I\'m just trying to see what other crazy things Florida man will do',
+                preview: 'reply to @other_user',
+                type: 'reply',
+                articleName: 'Florida Man does Something Crazy...Again'
+            ),
+            Comment(
+                text: 'Another sample comment to see what will happen',
+                preview: 'reply to @other_user2',
+                type: 'reply',
+                articleName: 'Some Random Event Happened'
+            ),
+            Comment(
+                text: 'Another sample comment to see what will happen',
+                preview: 'reply to @other_user2',
+                type: 'reply',
+                articleName: 'Some Random Event Happened'
+            ),
+            Comment(
+                text: 'Another sample comment to see what will happen',
+                preview: 'reply to @other_user2',
+                type: 'reply',
+                articleName: 'Some Random Event Happened'
+            ),
+            Comment(
+                text: 'Another sample comment to see what will happen',
+                preview: 'reply to @other_user2',
+                type: 'reply',
+                articleName: 'Some Random Event Happened'
+            )
+          ]
+      )
+    );
+  }
+}
+
+class Comment extends StatefulWidget {
+
+  final String text;
+  final String preview;
+  final String type;
+  final String articleName;
+
+  Comment({Key key, this.text, this.preview, this.type, this.articleName}): super(key: key);
+
+  _CommentState createState() => _CommentState();
+}
+
+class _CommentState extends State<Comment> {
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(top: 5, bottom: 5),
+        child: Container(
+            decoration: BoxDecoration(
+                color: Colors.white,
+                boxShadow: [
+                  BoxShadow(
+                      color: Color.fromRGBO(0, 0, 0, 0.08),
+                      blurRadius: 5,
+                      spreadRadius: 1,
+                      offset: Offset(2, 2)
+                  )
+                ]
+            ),
+            child: Padding(
+                padding: EdgeInsets.all(7),
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Padding(
+                        padding: EdgeInsets.only(bottom: 5),
+                        child: Text(widget.articleName, style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
+                      ),
+                      Padding(
+                        padding: EdgeInsets.only(bottom: 5),
+                        child: Text(widget.preview, style: TextStyle(fontSize: 12)),
+                      ),
+                      Text(widget.text, style: TextStyle(fontSize: 14))
+                    ]
+                )
+            )
+        )
+    );
+  }
+}

--- a/frontend/lib/profile/sections/following.dart
+++ b/frontend/lib/profile/sections/following.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+const int GRID_PADDING = 15;
+const int ITEMS_PER_ROW = 4;
+
+class FollowingSection extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return GridView.count(
+        scrollDirection: Axis.vertical,
+        shrinkWrap: true,
+        crossAxisCount: ITEMS_PER_ROW,
+        childAspectRatio: 0.8,
+        children: <Widget>[
+          FollowingProfileIcon(name: "John Smith"),
+          FollowingProfileIcon(name: "Jack Smith"),
+          FollowingProfileIcon(name: "Jake Smith with long name"),
+          FollowingProfileIcon(name: "James Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+          FollowingProfileIcon(name: "Jill Smith"),
+        ],
+    );
+  }
+}
+
+class FollowingProfileIcon extends StatelessWidget {
+  FollowingProfileIcon({Key key, this.name}): super(key: key);
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    int picLen = (MediaQuery.of(context).size.width ~/ ITEMS_PER_ROW) - GRID_PADDING;
+
+    return Column(
+      children: <Widget>[
+        Padding(
+          padding: EdgeInsets.only(top: 20, bottom: 7),
+          child: Container(
+            width: picLen.toDouble() - 10,
+            height: picLen.toDouble() - 10,
+            decoration: BoxDecoration(
+                image: DecorationImage(image: AssetImage('assets/defaultprofilepic.jpg')),
+                borderRadius: BorderRadius.all(Radius.circular(100))
+            ),
+          )
+        ),
+        Text(name, overflow: TextOverflow.ellipsis)
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Add components that supply a profile picture, name, username, along with three tabs containing details:
- Activity: latest comments/opinions on posts
- Following: News sources and/or topics the user follows
- About: Containing a description and contact information. As of now it has arbitrary text.
![Screenshot (Feb 15, 2020 5_58_06 PM)](https://user-images.githubusercontent.com/23279139/74597940-e3d64c00-501c-11ea-9fc8-cbb0f5698172.png)
![Screenshot (Feb 15, 2020 5_57_46 PM)](https://user-images.githubusercontent.com/23279139/74597942-e5077900-501c-11ea-9529-9365af354870.png)
![Screenshot (Feb 15, 2020 5_57_23 PM)](https://user-images.githubusercontent.com/23279139/74597943-e638a600-501c-11ea-9360-72bf77626bae.png)



