### PR TITLE
Fetch user data while splash screen is showing

### DIFF
--- a/frontend/lib/profile/section-control/section_control.dart
+++ b/frontend/lib/profile/section-control/section_control.dart
@@ -20,7 +20,7 @@ class _SectionControlState extends State<SectionControl> {
     setState(() {
       currentPage = page;
     });
-    _controller.animateToPage(page, duration: Duration(milliseconds: 1000), curve: Curves.easeInOut);
+    _controller.animateToPage(page, duration: Duration(seconds: 1), curve: Curves.easeInOut);
     _controller.jumpToPage(page);
   }
 
@@ -34,7 +34,7 @@ class _SectionControlState extends State<SectionControl> {
               children: <Widget>[
                 ActivitySection(),
                 FollowingSection(),
-                AboutSection(description: 'hello this is my description and it spans multiple rows just trying it out right now')
+                AboutSection()
               ],
               onPageChanged: _changeSection,
               controller: _controller,

--- a/frontend/lib/profile/sections/about.dart
+++ b/frontend/lib/profile/sections/about.dart
@@ -1,17 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:outlook/user_state.dart';
+import 'package:provider/provider.dart';
 
 class AboutSection extends StatelessWidget {
-  AboutSection({Key key, this.description}): super(key: key);
-
-  final String description;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Padding(
-        padding: EdgeInsets.all(20),
-        child: Text(description, style: TextStyle(fontSize: 16))
-      )
+    return Consumer<UserState>(
+      builder: (context, userState, child) {
+       return Container(
+           child: Padding(
+               padding: EdgeInsets.all(20),
+               child: Text(userState.description, style: TextStyle(fontSize: 16))
+           )
+       );
+      }
     );
   }
 }

--- a/frontend/lib/user_state.dart
+++ b/frontend/lib/user_state.dart
@@ -1,10 +1,18 @@
 import 'package:flutter/cupertino.dart';
 
 class UserState extends ChangeNotifier {
+  UserState({this.name, this.username, this.email, this.id, this.description});
 
-  String name = "Clayton Chu";
-  String username = "clayton";
-  String email = "clayton@example.com";
+  int id = 0;
+  String name = "";
+  String username = "";
+  String email = "";
+  String description = "";
+
+  void setUsername(String username) {
+    this.username = username;
+    notifyListeners();
+  }
 
   void setName(String name) {
     this.name = name;
@@ -14,5 +22,15 @@ class UserState extends ChangeNotifier {
   void setEmail(String email) {
     this.email = email;
     notifyListeners();
+  }
+
+  factory UserState.fromJson(Map<String, dynamic> json) {
+    return UserState(
+      id: json['pk'],
+      name: "${json['fields']['first_name']} ${json['fields']['last_name']}",
+      username: json['fields']['user_name'],
+      email: json['fields']['email_address'],
+      description: json['fields']['description']
+    );
   }
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -130,6 +130,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.0+4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.3"
   image:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_form_builder:
   provider:
   tuple:
+  http:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
A brief loading screen appears until user (and other essential) data is properly fetched. This is to prevent the user from using the app and potentially seeing uninitialized information. Fetching posts is not affected by this.

Kind of looks like Medium's splash screen, can probably revise later.

Fixes #34 .

![Screenshot (Feb 18, 2020 5_33_54 PM)](https://user-images.githubusercontent.com/23279139/74793353-efbc4b00-5274-11ea-8546-c11b2906303b.png)

