### PR TITLE
Add profile page retrieval from firebase

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -24,6 +24,7 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdkVersion 28
@@ -61,6 +62,7 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.google.firebase:firebase-analytics:17.2.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 

--- a/frontend/android/google-services.json
+++ b/frontend/android/google-services.json
@@ -1,0 +1,47 @@
+{
+  "project_info": {
+    "project_number": "448604861097",
+    "firebase_url": "https://outlook-e8e79.firebaseio.com",
+    "project_id": "outlook-e8e79",
+    "storage_bucket": "outlook-e8e79.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:448604861097:android:b8c5dd4d8acdc1ee5f2fb8",
+        "android_client_info": {
+          "package_name": "com.package.outlook"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "448604861097-diud87hcs31a2rpe30bj38f6uim8ngmj.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDc5eJa5u2t1OljMRbLlF5ygvmllhE2Dfw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "448604861097-diud87hcs31a2rpe30bj38f6uim8ngmj.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "448604861097-ivm1kicnr1rggclg9dcubv4ir3e3g3a9.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.package.outlook"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/frontend/lib/firebase_manager.dart
+++ b/frontend/lib/firebase_manager.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:firebase_core/firebase_core.dart';
+
+class FirebaseManager {
+  static FirebaseStorage _storage = null;
+
+  static getInstance() async {
+    if (_storage == null) {
+      final FirebaseApp app = await FirebaseApp.configure(
+        name: 'Outlook',
+        options: FirebaseOptions(
+          googleAppID: Platform.isIOS
+              ? '1:448604861097:ios:66935a43aa371e5b5f2fb8'
+              : '1:448604861097:android:b8c5dd4d8acdc1ee5f2fb8',
+          gcmSenderID: '448604861097',
+          apiKey: 'AIzaSyBAcu-7eYDwVX_9w7cKTClyvWRbdQ4oojI',
+          projectID: 'outlook-e8e79',
+        ),
+      );
+      FirebaseManager._storage = FirebaseStorage(
+          app: app, storageBucket: 'gs://outlook-e8e79.appspot.com/');
+    }
+    return FirebaseManager._storage;
+  }
+
+  static Future<String> getProfilePicture(String username) async {
+    final ref = _storage.ref().child("propic_${username}.jpg");
+    String url;
+    try {
+      url = await ref.getDownloadURL();
+    } catch (e) {
+      url = "";
+    }
+    return url;
+  }
+}

--- a/frontend/lib/profile/cover.dart
+++ b/frontend/lib/profile/cover.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'dart:math';
+import 'package:provider/provider.dart';
+import 'package:outlook/user_state.dart';
 
 /// Renders the user's profile picture, name, username, and optionally, a cover photo.
 class Cover extends StatefulWidget {
@@ -39,23 +42,27 @@ class _CoverState extends State<Cover> {
 class ProfilePicture extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      constraints: BoxConstraints(
-          maxHeight: 120,
-          maxWidth: 120
-      ),
-      decoration: BoxDecoration(
-          borderRadius: BorderRadius.all(Radius.circular(100)),
-          image:  DecorationImage(
-              image: AssetImage('assets/defaultprofilepic.jpg')
+    return Consumer<UserState>(
+      builder: (context, userState, child) {
+        return Container(
+          constraints: BoxConstraints(
+              maxHeight: 120,
+              maxWidth: 120
           ),
-          boxShadow: [
-            BoxShadow(
-                color: Color.fromRGBO(0, 0, 0, 0.2),
-                blurRadius: 8
-            )
-          ]
-      ),
+          decoration: BoxDecoration(
+              borderRadius: BorderRadius.all(Radius.circular(100)),
+              image:  DecorationImage(
+                  image: userState.profilepic.length > 0 ? NetworkImage(userState.profilepic) : AssetImage('assets/defaultprofilepic.jpg')
+              ),
+              boxShadow: [
+                BoxShadow(
+                    color: Color.fromRGBO(0, 0, 0, 0.2),
+                    blurRadius: 8
+                )
+              ]
+          ),
+        );
+      }
     );
   }
 }

--- a/frontend/lib/profile/profile_page.dart
+++ b/frontend/lib/profile/profile_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:outlook/firebase_manager.dart';
 import 'package:outlook/profile/cover.dart';
 import 'package:outlook/profile/edit_profile_page.dart';
 import 'package:outlook/profile/section-control/section_control.dart';

--- a/frontend/lib/user_state.dart
+++ b/frontend/lib/user_state.dart
@@ -9,6 +9,7 @@ class UserState extends ChangeNotifier {
   String username = "";
   String email = "";
   String description = "";
+  String profilepic = "";
 
   /// If a different user logs in, the username is changed.
   void setUsername(String username) {
@@ -37,6 +38,11 @@ class UserState extends ChangeNotifier {
   /// If a different user logs in or the user edits this, the user description is changed.
   void setDescription(String description) {
     this.description = description;
+    notifyListeners();
+  }
+
+  void setProfilePic(String url) {
+    this.profilepic = url;
     notifyListeners();
   }
 

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -85,6 +85,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  firebase:
+    dependency: transitive
+    description:
+      name: firebase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.1"
+  firebase_core:
+    dependency: "direct main"
+    description:
+      name: firebase_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.4"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1+2"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -177,6 +212,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1+1"
   matcher:
     dependency: transitive
     description:
@@ -393,5 +435,5 @@ packages:
     source: hosted
     version: "3.5.0"
 sdks:
-  dart: ">=2.6.0 <3.0.0"
+  dart: ">=2.7.0-dev <3.0.0"
   flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
   provider:
   tuple:
   http:
+  firebase_core:
+  firebase_storage:
 
   cached_network_image: 2.0.0-rc
   video_player: ^0.10.2+3


### PR DESCRIPTION
I've added a firebase storage to store all the user pictures and profile pictures; when the app loads, it will attempt to get the user's profile picture url, and if it doesn't exist, it will just use the default profile picture icon.

API key and log in stuff is still there because it's a small, shared test storage among the team and would be somewhat inconvenient to send everyone an `.env` file over something trivial.