### PR TITLE
Use password hash instead of plaintext pass

### DIFF
--- a/backend/outlook/backend/views.py
+++ b/backend/outlook/backend/views.py
@@ -44,7 +44,8 @@ def signup(request):
         validate_password(data["password"])
     except:
         return HttpResponse("Password is not strong enough.", status=400)
-    new_user = User(username=data["username"], password=data["password"])
+    new_user = User(username=data["username"])
+    new_user.set_password(data["password"])
     new_user.save()
     new_profile = Profile(first_name=data["firstname"], last_name=data["lastname"])
     new_profile.user = new_user


### PR DESCRIPTION
Fixes #63 . Use `set_password()` instead of filling in the password field with plaintext. Then the `authenticate()` call in `views.login()` will work properly.